### PR TITLE
setMaxTotal added as "pool max active" for DBCP2

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/connectionpool/DBCP2ConnectionPoolFactory.java
+++ b/src/main/java/org/datanucleus/store/rdbms/connectionpool/DBCP2ConnectionPoolFactory.java
@@ -92,15 +92,14 @@ public class DBCP2ConnectionPoolFactory extends AbstractConnectionPoolFactory
                     connectionPool.setMinIdle(value);
                 }
             }
-            // TODO What is the equivalent of this in DBCP2?
-            /*if (storeMgr.hasProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_ACTIVE))
+            if (storeMgr.hasProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_ACTIVE))
             {
                 int value = storeMgr.getIntProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_ACTIVE);
                 if (value > 0)
                 {
-                    connectionPool.setMaxActive(value);
+                    connectionPool.setMaxTotal(value);
                 }
-            }*/
+            }
             if (storeMgr.hasProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_WAIT))
             {
                 int value = storeMgr.getIntProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_WAIT);


### PR DESCRIPTION
the max total value is the maximum amount of active connections. On high load we get max total connections and the min and max idle values are ignored. On low load the idle configuration is respected.

In my opinion setMaxTotal is the correct method.
