### PR TITLE
Fix for NUCRDBMS-836

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/mapping/OracleRDBMSMappingManager.java
+++ b/src/main/java/org/datanucleus/store/rdbms/mapping/OracleRDBMSMappingManager.java
@@ -66,6 +66,7 @@ public class OracleRDBMSMappingManager extends RDBMSMappingManager
      * @param fieldRole Role of this column for the field (e.g collection element)
      * @return The mapping class to use
      */
+    @Override
     protected Class getOverrideMappingClass(Class mappingClass, AbstractMemberMetaData mmd, FieldRole fieldRole)
     {
         // Override some mappings with Oracle-specific mappings

--- a/src/main/java/org/datanucleus/store/rdbms/mapping/RDBMSMappingManager.java
+++ b/src/main/java/org/datanucleus/store/rdbms/mapping/RDBMSMappingManager.java
@@ -213,6 +213,7 @@ public class RDBMSMappingManager implements MappingManager
             MappingConverterDetails mcd = getMappingClass(javaType, serialised, embedded, null, null); // TODO Pass in 4th arg?
 
             Class mc = mcd.mappingClass;
+            mc = getOverrideMappingClass(mc, null, null);
             try
             {
                 JavaTypeMapping m = (JavaTypeMapping)mc.newInstance();
@@ -262,6 +263,7 @@ public class RDBMSMappingManager implements MappingManager
     {
         MappingConverterDetails mcd = getMappingClass(javaType, serialised, embedded, null, fieldName); // TODO Pass in 4th arg?
         Class mc = mcd.mappingClass;
+        mc = getOverrideMappingClass(mc, null, null);
         try
         {
             JavaTypeMapping m = (JavaTypeMapping)mc.newInstance();
@@ -434,6 +436,7 @@ public class RDBMSMappingManager implements MappingManager
         if (mcd != null)
         {
             mc = mcd.mappingClass;
+            mc = getOverrideMappingClass(mc, mmd, fieldRole);
         }
         if (mc != null && (mcd == null || mcd.typeConverter == null))
         {
@@ -1236,6 +1239,18 @@ public class RDBMSMappingManager implements MappingManager
                 NucleusLogger.DATASTORE.debug(Localiser.msg("054010", mapping.javaType, mapping.jdbcType, mapping.sqlType));
             }
         }
+    }
+    
+    /**
+     * Convenience method to allow overriding of particular mapping classes.
+     * @param mappingClass The mapping class selected
+     * @param mmd Meta data for the member (if appropriate)
+     * @param fieldRole Role for the field (e.g collection element)
+     * @return The mapping class to use
+     */
+    protected Class getOverrideMappingClass(Class mappingClass, AbstractMemberMetaData mmd, FieldRole fieldRole)
+    {
+        return mappingClass;
     }
 
     /**


### PR DESCRIPTION
- RDBMSMappingManager method added
- OracleRDBMSMappingManager overrides the method now
- method used as in Datanucleus 3.2
