### PR TITLE
Allow selection multi-valued objects if stored in a single column

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/query/JDOQLQuery.java
+++ b/src/main/java/org/datanucleus/store/rdbms/query/JDOQLQuery.java
@@ -353,7 +353,7 @@ public class JDOQLQuery extends AbstractJDOQLQuery
                                 AbstractMemberMetaData mmd = idx.getMapping().getMemberMetaData();
                                 if (mmd != null)
                                 {
-                                    if ((mmd.hasCollection() || mmd.hasMap() || mmd.hasArray()) && idx.getMapping() instanceof AbstractContainerMapping)
+                                    if ((mmd.hasCollection() || mmd.hasMap() || mmd.hasArray()) && idx.getMapping() instanceof AbstractContainerMapping && idx.getMapping().getNumberOfDatastoreMappings() > 1)
                                     {
                                         throw new NucleusUserException(Localiser.msg("021213"));
                                     }

--- a/src/main/java/org/datanucleus/store/rdbms/query/QueryToSQLMapper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/query/QueryToSQLMapper.java
@@ -831,7 +831,7 @@ public class QueryToSQLMapper extends AbstractExpressionEvaluator implements Que
         JavaTypeMapping m = sqlExpr.getJavaTypeMapping();
         if (m != null)
         {
-            if (m instanceof AbstractContainerMapping)
+            if (m instanceof AbstractContainerMapping && m.getNumberOfDatastoreMappings() > 1)
             {
                 throw new NucleusUserException(Localiser.msg("021213"));
             }


### PR DESCRIPTION
This allows serialized members to be used in queries where a resultClass is specified.

See discussion here http://www.datanucleus.org/servlet/forum/viewthread_thread,7829