### PR TITLE
properly propagate jdbc timeouts for SQL queries

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/query/SQLQuery.java
+++ b/src/main/java/org/datanucleus/store/rdbms/query/SQLQuery.java
@@ -640,7 +640,7 @@ public final class SQLQuery extends Query
                         }
 
                         // Apply any user-specified constraints over timeouts and ResultSet
-                        RDBMSQueryUtils.prepareStatementForExecution(ps, this, false);
+                        RDBMSQueryUtils.prepareStatementForExecution(ps, this, true);
 
                         ResultSet rs = sqlControl.executeStatementQuery(ec, mconn, compiledSQL, ps);
                         try
@@ -754,7 +754,7 @@ public final class SQLQuery extends Query
                         }
 
                         // Apply any user-specified constraints over timeouts etc
-                        RDBMSQueryUtils.prepareStatementForExecution(ps, this, false);
+                        RDBMSQueryUtils.prepareStatementForExecution(ps, this, true);
 
                         sqlControl.executeStatement(ec, mconn, compiledSQL, ps);
                     }
@@ -1011,6 +1011,11 @@ public final class SQLQuery extends Query
     {
         // We support cancel via JDBC PreparedStatement.cancel();
     }
+
+    protected boolean supportsTimeout() {
+        return true;
+    }
+
 
     /**
      * Method to generate a ResultObjectFactory for converting rows of the provided ResultSet into


### PR DESCRIPTION
fix #44 (tests in datanucleus/tests/#6 )