### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/JDBCUtils.java
+++ b/src/main/java/org/datanucleus/store/rdbms/JDBCUtils.java
@@ -34,6 +34,8 @@ import org.datanucleus.util.NucleusLogger;
  */
 public class JDBCUtils
 {
+    private JDBCUtils(){}
+
     /**
      * Method to return the "subprotocol" for a JDBC URL.
      * A JDBC URL is made up of

--- a/src/main/java/org/datanucleus/store/rdbms/RDBMSPropertyNames.java
+++ b/src/main/java/org/datanucleus/store/rdbms/RDBMSPropertyNames.java
@@ -22,6 +22,8 @@ package org.datanucleus.store.rdbms;
  */
 public class RDBMSPropertyNames
 {
+    private RDBMSPropertyNames(){}
+
     public static final String PROPERTY_RDBMS_LEGACY_NATIVE_VALUE_STRATEGY = "datanucleus.rdbms.useLegacyNativeValueStrategy";
     public static final String PROPERTY_RDBMS_DYNAMIC_SCHEMA_UPDATES = "datanucleus.rdbms.dynamicSchemaUpdates";
     public static final String PROPERTY_RDBMS_TABLE_COLUMN_ORDER = "datanucleus.rdbms.tableColumnOrder";

--- a/src/main/java/org/datanucleus/store/rdbms/RDBMSStoreHelper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/RDBMSStoreHelper.java
@@ -50,6 +50,7 @@ import org.datanucleus.util.NucleusLogger;
  */
 public class RDBMSStoreHelper
 {
+    private RDBMSStoreHelper(){}
     /**
      * Utility that does a discriminator candidate query for the specified candidate and subclasses
      * and returns the class name of the instance that has the specified identity (if any).

--- a/src/main/java/org/datanucleus/store/rdbms/adapter/DerbySQLFunction.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/DerbySQLFunction.java
@@ -23,6 +23,7 @@ package org.datanucleus.store.rdbms.adapter;
  */
 public class DerbySQLFunction
 {
+    private DerbySQLFunction(){}
     /**
      * ASCII code.
      * @param code The code

--- a/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/jocl/ConstructorUtil.java
+++ b/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/jocl/ConstructorUtil.java
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
  * @version $Revision: 479137 $ $Date: 2006-11-25 10:51:48 -0500 (Sat, 25 Nov 2006) $
  */
 public class ConstructorUtil {
+    private ConstructorUtil(){}
     /**
      * Returns a {@link Constructor} for the given method signature, or <tt>null</tt>
      * if no such <tt>Constructor</tt> can be found.

--- a/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/pool/PoolUtils.java
+++ b/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/pool/PoolUtils.java
@@ -47,7 +47,7 @@ public final class PoolUtils {
      * Instead, the class should be used procedurally: PoolUtils.adapt(aPool);.
      * This constructor is public to permit tools that require a JavaBean instance to operate.
      */
-    public PoolUtils() {
+    private PoolUtils() {
     }
 
     /**

--- a/src/main/java/org/datanucleus/store/rdbms/mapping/MappingHelper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/mapping/MappingHelper.java
@@ -44,6 +44,7 @@ import org.datanucleus.util.NucleusLogger;
  */
 public class MappingHelper
 {
+    private MappingHelper(){}
     /**
      * Convenience method to return an array of positions for datastore columns for the supplied
      * mapping and the initial position value. For example if the mapping has a single datastore

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/BackingStoreHelper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/BackingStoreHelper.java
@@ -46,6 +46,8 @@ import org.datanucleus.store.rdbms.table.Table;
  */
 public class BackingStoreHelper
 {
+    private BackingStoreHelper(){}
+
     /**
      * Convenience method to populate the passed PreparedStatement with the value from the owner.
      * @param op ObjectProvider

--- a/src/main/java/org/datanucleus/store/rdbms/sql/SQLStatementHelper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/sql/SQLStatementHelper.java
@@ -72,6 +72,8 @@ import org.datanucleus.util.NucleusLogger;
  */
 public class SQLStatementHelper
 {
+    private SQLStatementHelper(){}
+
     /**
      * Convenience method to return a PreparedStatement for an SQLStatement.
      * @param sqlStmt The query expression

--- a/src/main/java/org/datanucleus/store/rdbms/sql/expression/ExpressionUtils.java
+++ b/src/main/java/org/datanucleus/store/rdbms/sql/expression/ExpressionUtils.java
@@ -51,6 +51,8 @@ import org.datanucleus.util.NucleusLogger;
  */
 public class ExpressionUtils
 {
+    private ExpressionUtils(){}
+
     /**
      * Method to return a numeric expression for the supplied SQL expression.
      * Makes use of the RDBMS function to convert to a numeric.

--- a/src/main/java/org/datanucleus/store/rdbms/table/TableUtils.java
+++ b/src/main/java/org/datanucleus/store/rdbms/table/TableUtils.java
@@ -44,6 +44,7 @@ import org.datanucleus.store.rdbms.mapping.java.ReferenceMapping;
  */
 public class TableUtils
 {
+    private TableUtils(){}
     /**
      * Convenience method to add foreign-keys for the specified reference field.
      * Adds FKs from the column(s) in this table to the ID column(s) of the PC table of the implementation type.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.

You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Soso Tughushi