### PR TITLE
squid:S2130, Parsing should be used to convert "Strings" to primitives

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/RDBMSStoreManager.java
+++ b/src/main/java/org/datanucleus/store/rdbms/RDBMSStoreManager.java
@@ -1294,7 +1294,7 @@ public class RDBMSStoreManager extends AbstractStoreManager implements BackedSCO
                     int jdbcTypeNumber = 0;
                     try
                     {
-                        jdbcTypeNumber = Short.valueOf(jdbcTypeStr).shortValue();
+                        jdbcTypeNumber = Short.parseShort(jdbcTypeStr);
                     }
                     catch (NumberFormatException nfe) { }
 
@@ -2616,7 +2616,7 @@ public class RDBMSStoreManager extends AbstractStoreManager implements BackedSCO
                     short jdbcTypeNumber = 0;
                     try
                     {
-                        jdbcTypeNumber = Short.valueOf(jdbcTypeStr).shortValue();
+                        jdbcTypeNumber = Short.parseShort(jdbcTypeStr);
                     }
                     catch (NumberFormatException nfe) { }
                     JDBCTypeInfo jdbcType = (JDBCTypeInfo)typesInfo.getChild(jdbcTypeStr);

--- a/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/BasicDataSourceFactory.java
+++ b/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/BasicDataSourceFactory.java
@@ -162,12 +162,12 @@ public class BasicDataSourceFactory implements ObjectFactory {
 
         value = properties.getProperty(PROP_DEFAULTAUTOCOMMIT);
         if (value != null) {
-            dataSource.setDefaultAutoCommit(Boolean.valueOf(value).booleanValue());
+            dataSource.setDefaultAutoCommit(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_DEFAULTREADONLY);
         if (value != null) {
-            dataSource.setDefaultReadOnly(Boolean.valueOf(value).booleanValue());
+            dataSource.setDefaultReadOnly(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_DEFAULTTRANSACTIONISOLATION);
@@ -238,12 +238,12 @@ public class BasicDataSourceFactory implements ObjectFactory {
 
         value = properties.getProperty(PROP_TESTONBORROW);
         if (value != null) {
-            dataSource.setTestOnBorrow(Boolean.valueOf(value).booleanValue());
+            dataSource.setTestOnBorrow(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_TESTONRETURN);
         if (value != null) {
-            dataSource.setTestOnReturn(Boolean.valueOf(value).booleanValue());
+            dataSource.setTestOnReturn(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_TIMEBETWEENEVICTIONRUNSMILLIS);
@@ -263,7 +263,7 @@ public class BasicDataSourceFactory implements ObjectFactory {
 
         value = properties.getProperty(PROP_TESTWHILEIDLE);
         if (value != null) {
-            dataSource.setTestWhileIdle(Boolean.valueOf(value).booleanValue());
+            dataSource.setTestWhileIdle(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_PASSWORD);
@@ -293,12 +293,12 @@ public class BasicDataSourceFactory implements ObjectFactory {
         
         value = properties.getProperty(PROP_ACCESSTOUNDERLYINGCONNECTIONALLOWED);
         if (value != null) {
-            dataSource.setAccessToUnderlyingConnectionAllowed(Boolean.valueOf(value).booleanValue());
+            dataSource.setAccessToUnderlyingConnectionAllowed(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_REMOVEABANDONED);
         if (value != null) {
-            dataSource.setRemoveAbandoned(Boolean.valueOf(value).booleanValue());
+            dataSource.setRemoveAbandoned(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_REMOVEABANDONEDTIMEOUT);
@@ -308,12 +308,12 @@ public class BasicDataSourceFactory implements ObjectFactory {
 
         value = properties.getProperty(PROP_LOGABANDONED);
         if (value != null) {
-            dataSource.setLogAbandoned(Boolean.valueOf(value).booleanValue());
+            dataSource.setLogAbandoned(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_POOLPREPAREDSTATEMENTS);
         if (value != null) {
-            dataSource.setPoolPreparedStatements(Boolean.valueOf(value).booleanValue());
+            dataSource.setPoolPreparedStatements(Boolean.parseBoolean(value));
         }
 
         value = properties.getProperty(PROP_MAXOPENPREPAREDSTATEMENTS);

--- a/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/cpdsadapter/DriverAdapterCPDS.java
+++ b/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/cpdsadapter/DriverAdapterCPDS.java
@@ -307,8 +307,8 @@ public class DriverAdapterCPDS
 
                 ra = ref.get("poolPreparedStatements");
                 if (ra != null && ra.getContent() != null) {
-                    setPoolPreparedStatements(Boolean.valueOf(
-                        ra.getContent().toString()).booleanValue());
+                    setPoolPreparedStatements(Boolean.parseBoolean(
+                        ra.getContent().toString()));
                 }
                 ra = ref.get("maxActive");
                 if (ra != null && ra.getContent() != null) {

--- a/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/datasources/InstanceKeyObjectFactory.java
+++ b/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp/datasources/InstanceKeyObjectFactory.java
@@ -52,7 +52,7 @@ abstract class InstanceKeyObjectFactory
             if (obj instanceof String)
             {
                 try {
-                    max = Math.max(max, Integer.valueOf((String)obj).intValue());
+                    max = Math.max(max, Integer.parseInt((String) obj));
                 }
                 catch (NumberFormatException e) {
                     // no sweat, ignore those keys
@@ -134,14 +134,14 @@ abstract class InstanceKeyObjectFactory
 
         ra = ref.get("defaultAutoCommit");
         if (ra != null && ra.getContent() != null) {
-            ikds.setDefaultAutoCommit(Boolean.valueOf(
-                ra.getContent().toString()).booleanValue());
+            ikds.setDefaultAutoCommit(Boolean.parseBoolean(
+                    ra.getContent().toString()));
         }
 
         ra = ref.get("defaultReadOnly");
         if (ra != null && ra.getContent() != null) {
-            ikds.setDefaultReadOnly(Boolean.valueOf(
-                ra.getContent().toString()).booleanValue());
+            ikds.setDefaultReadOnly(Boolean.parseBoolean(
+                    ra.getContent().toString()));
         }
 
         ra = ref.get("description");
@@ -164,14 +164,14 @@ abstract class InstanceKeyObjectFactory
 
         ra = ref.get("testOnBorrow");
         if (ra != null && ra.getContent() != null) {
-            ikds.setTestOnBorrow(Boolean.valueOf(
-                ra.getContent().toString()).booleanValue());
+            ikds.setTestOnBorrow(Boolean.parseBoolean(
+                    ra.getContent().toString()));
         }
 
         ra = ref.get("testOnReturn");
         if (ra != null && ra.getContent() != null) {
-            ikds.setTestOnReturn(Boolean.valueOf(
-                ra.getContent().toString()).booleanValue());
+            ikds.setTestOnReturn(Boolean.parseBoolean(
+                    ra.getContent().toString()));
         }
 
         ra = ref.get("timeBetweenEvictionRunsMillis");
@@ -194,8 +194,8 @@ abstract class InstanceKeyObjectFactory
 
         ra = ref.get("testWhileIdle");
         if (ra != null && ra.getContent() != null) {
-            ikds.setTestWhileIdle(Boolean.valueOf(
-                ra.getContent().toString()).booleanValue());
+            ikds.setTestWhileIdle(Boolean.parseBoolean(
+                    ra.getContent().toString()));
         }
 
         ra = ref.get("validationQuery");

--- a/src/main/java/org/datanucleus/store/rdbms/mapping/datastore/BigIntRDBMSMapping.java
+++ b/src/main/java/org/datanucleus/store/rdbms/mapping/datastore/BigIntRDBMSMapping.java
@@ -184,7 +184,7 @@ public class BigIntRDBMSMapping extends AbstractDatastoreMapping
             {
                 if (column != null && column.isDefaultable() && column.getDefaultValue() != null && !StringUtils.isWhitespace(column.getDefaultValue().toString()))
                 {
-                    ps.setLong(param, Long.valueOf(column.getDefaultValue().toString().trim()).longValue());
+                    ps.setLong(param, Long.parseLong(column.getDefaultValue().toString().trim()));
                 }
                 else
                 {
@@ -200,7 +200,7 @@ public class BigIntRDBMSMapping extends AbstractDatastoreMapping
                 else if (value instanceof String)
                 {
                     // User requested to store a String as an INTEGER! Why would anyone do that?
-                    ps.setLong(param, Long.valueOf((String)value).longValue());
+                    ps.setLong(param, Long.parseLong((String) value));
                 }
                 else if (value instanceof java.util.Date)
                 {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - “ Parsing should be used to convert "Strings" to primitives”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.
Soso Tughushi