### PR TITLE
use maxFetchDepth in calls to

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/scostore/FKArrayStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/FKArrayStore.java
@@ -710,7 +710,7 @@ public class FKArrayStore<E> extends AbstractArrayStore<E>
             iterateUsingDiscriminator = true;
 
             // Select the required fields
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, sqlStmt.getPrimaryTable(), elementCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
         }
         else
         {
@@ -731,7 +731,8 @@ public class FKArrayStore<E> extends AbstractArrayStore<E>
                     }
                     else
                     {
-                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, iteratorMappingClass, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, iteratorMappingClass, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 
+                            fp.getMaxFetchDepth());
                     }
                 }
                 else
@@ -742,7 +743,7 @@ public class FKArrayStore<E> extends AbstractArrayStore<E>
                     }
                     else
                     {
-                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, null, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, null, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), fp.getMaxFetchDepth());
                     }
                 }
 

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/FKListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/FKListStore.java
@@ -1553,7 +1553,7 @@ public class FKListStore<E> extends AbstractListStore<E>
             iterateUsingDiscriminator = true;
 
             // Select the required fields
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, stmtClassMapping, fp, sqlStmt.getPrimaryTable(), elementCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, stmtClassMapping, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
         }
         else
         {
@@ -1574,7 +1574,8 @@ public class FKListStore<E> extends AbstractListStore<E>
                     }
                     else
                     {
-                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, stmtClassMapping, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, stmtClassMapping, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(),
+                            fp.getMaxFetchDepth());
                     }
                 }
                 else
@@ -1585,7 +1586,8 @@ public class FKListStore<E> extends AbstractListStore<E>
                     }
                     else
                     {
-                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, null, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                        SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, null, fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(),
+                            fp.getMaxFetchDepth());
                     }
                 }
 

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/FKMapStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/FKMapStore.java
@@ -1250,7 +1250,7 @@ public class FKMapStore<K, V> extends AbstractMapStore<K, V>
             }
 
             // Select the value field(s)
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), valueCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), valueCmd, ec.getFetchPlan().getMaxFetchDepth());
         }
         else
         {
@@ -1264,7 +1264,7 @@ public class FKMapStore<K, V> extends AbstractMapStore<K, V>
                 SQLTable valueSqlTbl = sqlStmt.leftOuterJoin(sqlStmt.getPrimaryTable(), valueMapping, valueTable, null, valueTable.getIdMapping(), null, null);
 
                 // Select the value field(s)
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), valueSqlTbl, valueCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), valueSqlTbl, valueCmd, ec.getFetchPlan().getMaxFetchDepth());
             }
             else
             {

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/FKSetStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/FKSetStore.java
@@ -1223,7 +1223,7 @@ public class FKSetStore<E> extends AbstractSetStore<E>
 //            NucleusLogger.GENERAL.info(">> FKSetStore.iter iterMapDef=" + iteratorMappingDef + " table=" + sqlStmt.getPrimaryTable() +
 //                " emd=" + emd.getFullClassName() + " elem.subclasses=" + StringUtils.objectArrayToString(elemSubclasses));
             // Select the required fields (of the element class)
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, sqlStmt.getPrimaryTable(), elementCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
         }
         else
         {
@@ -1250,12 +1250,12 @@ public class FKSetStore<E> extends AbstractSetStore<E>
                     if (sqlStmt == null)
                     {
                         SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, iteratorMappingClass,
-                            fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                            fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), fp.getMaxFetchDepth());
                     }
                     else
                     {
                         SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(subStmt, null,
-                            fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), 0);
+                            fp, subStmt.getPrimaryTable(), elementInfo[i].getAbstractClassMetaData(), fp.getMaxFetchDepth());
                     }
                 }
                 else

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinArrayStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinArrayStore.java
@@ -347,7 +347,7 @@ public class JoinArrayStore<E> extends AbstractArrayStore<E>
 
             // Select the required fields
             SQLTable elementSqlTbl = sqlStmt.getTable(elementInfo[0].getDatastoreClass(), sqlStmt.getPrimaryTable().getGroupName());
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, fp.getMaxFetchDepth());
         }
 
         if (addRestrictionOnOwner)

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
@@ -998,7 +998,7 @@ public class JoinListStore<E> extends AbstractListStore<E>
 
             // Select the required fields
             SQLTable elementSqlTbl = sqlStmt.getTable(elementInfo[0].getDatastoreClass(), sqlStmt.getPrimaryTable().getGroupName());
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, stmtClassMapping, fp, elementSqlTbl, elementCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, stmtClassMapping, fp, elementSqlTbl, elementCmd, fp.getMaxFetchDepth());
         }
 
         if (addRestrictionOnOwner)

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinMapStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinMapStore.java
@@ -832,7 +832,7 @@ public class JoinMapStore<K, V> extends AbstractMapStore<K, V>
                     }
                 }
             }
-            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), valueSqlTbl, valueCmd, 0);
+            SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, getMappingDef, ec.getFetchPlan(), valueSqlTbl, valueCmd, ec.getFetchPlan().getMaxFetchDepth());
         }
 
         // Apply condition on owner field to filter by owner

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinSetStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinSetStore.java
@@ -1035,13 +1035,13 @@ public class JoinSetStore<E> extends AbstractSetStore<E>
 
                     // Select the required fields
                     SQLTable elementSqlTbl = sqlStmt.getTable(elementInfo[i].getDatastoreClass(), sqlStmt.getPrimaryTable().getGroupName());
-                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, 0);
+                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, fp.getMaxFetchDepth());
                 }
                 else
                 {
                     // Select the required fields
                     SQLTable elementSqlTbl = elementStmt.getTable(elementInfo[i].getDatastoreClass(), elementStmt.getPrimaryTable().getGroupName());
-                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(elementStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, 0);
+                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(elementStmt, iteratorMappingClass, fp, elementSqlTbl, elementCmd, fp.getMaxFetchDepth());
 
                     sqlStmt.union(elementStmt);
                 }

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/MapEntrySetStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/MapEntrySetStore.java
@@ -31,7 +31,6 @@ import org.datanucleus.ExecutionContext;
 import org.datanucleus.Transaction;
 import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.metadata.AbstractMemberMetaData;
-import org.datanucleus.metadata.MapMetaData.MapType;
 import org.datanucleus.state.ObjectProvider;
 import org.datanucleus.store.connection.ManagedConnection;
 import org.datanucleus.store.rdbms.exceptions.MappedDatastoreException;
@@ -435,20 +434,6 @@ class MapEntrySetStore<K, V> extends BaseContainerStore implements SetStore<Map.
     {
         SelectStatement sqlStmt = new SelectStatement(storeMgr, mapTable, null, null);
         sqlStmt.setClassLoaderResolver(clr);
-
-        MapType mapType = getOwnerMemberMetaData().getMap().getMapType();
-        if (mapType == MapType.MAP_TYPE_JOIN)
-        {
-            
-        }
-        else if (mapType == MapType.MAP_TYPE_KEY_IN_VALUE)
-        {
-            
-        }
-        else if (mapType == MapType.MAP_TYPE_VALUE_IN_KEY)
-        {
-            
-        }
 
         // Select the key mapping
         // TODO If key is persistable and has inheritance also select a discriminator to get the type

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/MapKeySetStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/MapKeySetStore.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.datanucleus.ClassLoaderResolver;
 import org.datanucleus.ExecutionContext;
+import org.datanucleus.FetchPlan;
 import org.datanucleus.Transaction;
 import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.metadata.DiscriminatorStrategy;
@@ -257,6 +258,7 @@ class MapKeySetStore<K> extends AbstractSetStore<K>
         final Class keyCls = clr.classForName(elementType);
         SQLTable containerSqlTbl = null;
         MapType mapType = getOwnerMemberMetaData().getMap().getMapType();
+        FetchPlan fp = ec.getFetchPlan();
         if (elementCmd != null && elementCmd.getDiscriminatorStrategyForTable() != null &&
             elementCmd.getDiscriminatorStrategyForTable() != DiscriminatorStrategy.NONE)
         {
@@ -285,7 +287,7 @@ class MapKeySetStore<K> extends AbstractSetStore<K>
                 containerSqlTbl = sqlStmt.getPrimaryTable();
 
                 iteratorMappingDef = new StatementClassMapping();
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
             else
             {
@@ -295,7 +297,7 @@ class MapKeySetStore<K> extends AbstractSetStore<K>
                 containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), keyIdMapping, containerTable, null, elementMapping, null, null);
 
                 iteratorMappingDef = new StatementClassMapping();
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
         }
         else
@@ -310,7 +312,7 @@ class MapKeySetStore<K> extends AbstractSetStore<K>
                 sqlStmt = stmtGen.getStatement(ec);
                 containerSqlTbl = sqlStmt.getPrimaryTable();
 
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
             else
             {
@@ -327,7 +329,7 @@ class MapKeySetStore<K> extends AbstractSetStore<K>
                     JavaTypeMapping keyIdMapping = sqlStmt.getPrimaryTable().getTable().getIdMapping();
                     containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), keyIdMapping, containerTable, null, elementMapping, null, null);
 
-                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
                 }
                 else
                 {

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/MapValueCollectionStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/MapValueCollectionStore.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.datanucleus.ClassLoaderResolver;
 import org.datanucleus.ExecutionContext;
+import org.datanucleus.FetchPlan;
 import org.datanucleus.Transaction;
 import org.datanucleus.exceptions.NucleusDataStoreException;
 import org.datanucleus.exceptions.NucleusUserException;
@@ -374,6 +375,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
         final Class valueCls = clr.classForName(elementType);
         SQLTable containerSqlTbl = null;
         MapType mapType = getOwnerMemberMetaData().getMap().getMapType();
+        FetchPlan fp = ec.getFetchPlan();
         if (elementCmd != null && elementCmd.getDiscriminatorStrategyForTable() != null && elementCmd.getDiscriminatorStrategyForTable() != DiscriminatorStrategy.NONE)
         {
             // Map<?, PC> where value has discriminator
@@ -403,7 +405,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                 containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), valueIdMapping, containerTable, null, elementMapping, null, null);
 
                 iteratorMappingDef = new StatementClassMapping();
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
             else if (mapType == MapType.MAP_TYPE_KEY_IN_VALUE)
             {
@@ -411,7 +413,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                 containerSqlTbl = sqlStmt.getPrimaryTable();
 
                 iteratorMappingDef = new StatementClassMapping();
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
             else
             {
@@ -420,7 +422,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                 containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), valueIdMapping, containerTable, null, elementMapping, null, null);
 
                 iteratorMappingDef = new StatementClassMapping();
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
         }
         else
@@ -440,8 +442,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                     JavaTypeMapping valueIdMapping = sqlStmt.getPrimaryTable().getTable().getIdMapping();
                     containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), valueIdMapping, containerTable, null, elementMapping, null, null);
 
-                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef,
-                        ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
                 }
                 else
                 {
@@ -473,7 +474,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                 sqlStmt = stmtGen.getStatement(ec);
                 containerSqlTbl = sqlStmt.getPrimaryTable();
 
-                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
             }
             else
             {
@@ -490,7 +491,7 @@ class MapValueCollectionStore<V> extends AbstractCollectionStore<V>
                     JavaTypeMapping valueIdMapping = sqlStmt.getPrimaryTable().getTable().getIdMapping();
                     containerSqlTbl = sqlStmt.innerJoin(sqlStmt.getPrimaryTable(), valueIdMapping, containerTable, null, elementMapping, null, null);
 
-                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, ec.getFetchPlan(), sqlStmt.getPrimaryTable(), elementCmd, 0);
+                    SQLStatementHelper.selectFetchPlanOfSourceClassInStatement(sqlStmt, iteratorMappingDef, fp, sqlStmt.getPrimaryTable(), elementCmd, fp.getMaxFetchDepth());
                 }
                 else
                 {


### PR DESCRIPTION
The goal of this pull request is to back port the solution of issue189 to branch 5.0:
use maxFetchDepth in calls to SQLStatementHelper.selectFetchPlanOfSourceClassInStatement. For #189. I did a git cherry-pick of the relevant commit of the master branch