### PR TITLE
Catch and Throw ClassCastException to provide details of the column with the issue

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/table/ColumnCreator.java
+++ b/src/main/java/org/datanucleus/store/rdbms/table/ColumnCreator.java
@@ -305,7 +305,15 @@ public final class ColumnCreator
                     {
                     	throw new NucleusUserException("Cannot create column for field "+mmd.getFullFieldName()+" column metadata "+colmd,ex);
                     }
-                    ((PersistableMapping) container).addJavaTypeMapping(refDatastoreMapping);
+
+                    try
+                    {
+                        ((PersistableMapping) container).addJavaTypeMapping(refDatastoreMapping);
+                    }
+                    catch (ClassCastException e)
+                    {
+                        throw new NucleusUserException("Failed to create column for field "+mmd.getFullFieldName()+". Cannot cast mapping to PersistableMapping.",e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Without catching and throwing this exception it is handled by a catch
much higher in the call stack which sees it as an 'unknown' exception
and has no details of the column with the issue.
This fixes that to provide more information in the log.
Note: appears to log multiple times (maybe just my logging) - it is in a for loop but that should not be
causing the multiple logging because the exception being raised should break out of the for loop.