### PR TITLE
Avoid passing null fieldNumbers array to generated dnProvideFields me…

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/RDBMSPersistenceHandler.java
+++ b/src/main/java/org/datanucleus/store/rdbms/RDBMSPersistenceHandler.java
@@ -661,6 +661,12 @@ public class RDBMSPersistenceHandler extends AbstractPersistenceHandler
      */
     private void checkForSchemaUpdatesForFieldsOfObject(ObjectProvider sm, int[] fieldNumbers)
     {
+        if (fieldNumbers == null || fieldNumbers.length == 0)
+        {
+            // Nothing to do for a class with no fields/attributes
+            return;
+        }
+
         if (storeMgr.getBooleanObjectProperty(RDBMSPropertyNames.PROPERTY_RDBMS_DYNAMIC_SCHEMA_UPDATES).booleanValue())
         {
             DynamicSchemaFieldManager dynamicSchemaFM = new DynamicSchemaFieldManager((RDBMSStoreManager)storeMgr, sm);


### PR DESCRIPTION
…thod in enhanced classes

An exception is thrown by generated method dnProvideFields in enhanced
classes if a null fieldNumbers array is passed to it. This prevents that
from happening.

I did the test before even checking the setting of the dynamic schema update property to short circuit even testing the value of that property but having no attributes is an extremely rare edge case so probably no real gain having it before the test for the property.