### PR TITLE
Make JDBCUtils methods null-safe

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/JDBCUtils.java
+++ b/src/main/java/org/datanucleus/store/rdbms/JDBCUtils.java
@@ -70,7 +70,10 @@ public class JDBCUtils
     {
         try
         {
-            logWarnings(conn.getWarnings());
+            if (conn != null)
+            {
+                logWarnings(conn.getWarnings());
+            }
         }
         catch (SQLException e)
         {
@@ -86,7 +89,10 @@ public class JDBCUtils
     {
         try
         {
-            logWarnings(stmt.getWarnings());
+            if (stmt != null)
+            {
+                logWarnings(stmt.getWarnings());
+            }
         }
         catch (SQLException e)
         {
@@ -102,7 +108,10 @@ public class JDBCUtils
     {
         try
         {
-            logWarnings(rs.getWarnings());
+            if (rs != null)
+            {
+                logWarnings(rs.getWarnings());
+            }
         }
         catch (SQLException e)
         {


### PR DESCRIPTION
I am using datanucleus-rdbms 5.1.11, and this follows a weird NPE I had after adding a field annotated with JPA Version annotation to a MappedSuperClass base class. 
Please see the stacktrace below. 
I found out that the AbstractRDBMSQueryResult#disconnect() method had already been called and therefore it had set the ResultSet value to null.
Maybe I've missed something, but I see no reason to break while attempting to log warnings if the ResultSet is already closed.

```
Caused by: javax.persistence.PersistenceException: Exception thrown while loading remaining rows of query                                                                                               [925/9955]
        at org.datanucleus.api.jpa.JPAAdapter.getUserExceptionForException(JPAAdapter.java:376)                                                                                                                   
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.closingConnection(ForwardQueryResult.java:302)                                                                                                    
        at org.datanucleus.store.query.AbstractQueryResult.disconnect(AbstractQueryResult.java:105)                                                                                                               
        at org.datanucleus.store.rdbms.query.AbstractRDBMSQueryResult.disconnect(AbstractRDBMSQueryResult.java:277)                                                                                               
        at org.datanucleus.store.rdbms.query.JPQLQuery$2.managedConnectionPreClose(JPQLQuery.java:654)                                                                                                            
        at org.datanucleus.store.rdbms.ConnectionFactoryImpl$ManagedConnectionImpl.close(ConnectionFactoryImpl.java:532)                                                                
        at org.datanucleus.store.connection.AbstractManagedConnection.release(AbstractManagedConnection.java:83)                                                                                                  
        at org.datanucleus.store.rdbms.ConnectionFactoryImpl$ManagedConnectionImpl.release(ConnectionFactoryImpl.java:371)                                                                                        
        at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:440)                                                                                                                        
        at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:316)                                                                                                      
        at org.datanucleus.state.StateManagerImpl.loadFieldsFromDatastore(StateManagerImpl.java:1500)                                                                                                             
        at org.datanucleus.state.StateManagerImpl.loadUnloadedFieldsInFetchPlan(StateManagerImpl.java:3879)                                                                                                       
        at org.datanucleus.store.rdbms.mapping.java.PersistableMapping.getObject(PersistableMapping.java:780)        
        at org.datanucleus.store.rdbms.query.ResultClassROF.getObject(ResultClassROF.java:254)                                                                                                                    
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.nextResultSetElement(ForwardQueryResult.java:180)                                                                                                 
        at org.datanucleus.store.rdbms.query.ForwardQueryResult$QueryResultIterator.next(ForwardQueryResult.java:408)                                                                                             
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.processNumberOfResults(ForwardQueryResult.java:136)                                                                                               
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.advanceToEndOfResultSet(ForwardQueryResult.java:164)                                                                                              
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.closingConnection(ForwardQueryResult.java:290)                                                                                                            ... 502 more                                                                                                                                                                                              
Caused by: java.lang.NullPointerException                                                                                                                                                                         
        at org.datanucleus.store.rdbms.JDBCUtils.logWarnings(JDBCUtils.java:106)                                                                                                                                  
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.nextResultSetElement(ForwardQueryResult.java:181)                                                                                                 
        at org.datanucleus.store.rdbms.query.ForwardQueryResult$QueryResultIterator.next(ForwardQueryResult.java:408)                                                                                             
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.processNumberOfResults(ForwardQueryResult.java:136)
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.advanceToEndOfResultSet(ForwardQueryResult.java:164)
        at org.datanucleus.store.rdbms.query.ForwardQueryResult.closingConnection(ForwardQueryResult.java:290)
        ... 519 more
```
