### PR TITLE
Prevent potential race condition by providing an intrinsic lock on 'SQLStatement#invalidateSQL()' method

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/sql/SQLStatement.java
+++ b/src/main/java/org/datanucleus/store/rdbms/sql/SQLStatement.java
@@ -952,7 +952,7 @@ public abstract class SQLStatement
     /**
      * Method to uncache the generated SQL (because some condition has changed).
      */
-    protected void invalidateStatement()
+    protected synchronized void invalidateStatement()
     {
         sql = null;
     }


### PR DESCRIPTION
Hi there!

Earlier today, I had a pretty-random NPE occurring when attempting to fetch data (with collections and maps fetched eagerly) concurrently.
The root cause was here: https://github.com/datanucleus/datanucleus-rdbms/blob/7062558e55b9ab37a385f5821ff989c512137d77/src/main/java/org/datanucleus/store/rdbms/sql/SelectStatement.java#L654

A breakpoint at that line revealed that the `sql` instance variable was actually `null`, which was due to a call to `SelectStatement#invalidateStatement()` occurring at a random pace:  https://github.com/datanucleus/datanucleus-rdbms/blob/7062558e55b9ab37a385f5821ff989c512137d77/src/main/java/org/datanucleus/store/rdbms/sql/SQLStatement.java#L960

This issue is a typical race condition (difficult to reproduce and provide a deterministic test case for), but I'll attach the exact stracktrace as soon as it occurs again.

Since `SelectStatement#getSQLText()` is synchronized, I was wondering why the `SQLStatement#invalidateStatement()` method was not. By synchronizing the `SQLStatement#invalidateStatement()` instance method, the issue seems to no longer occur after a lot of tests.

Feel free to comment if I've missed something.

Thanks.

EDIT: 
I am currently using datanucleus-rdbms 5.1.11, but the issue still occurred with 5.2.0-release. Below is the exact root cause exception stacktrace I found:
```
Caused by: java.lang.NullPointerException: null
        at org.datanucleus.store.rdbms.sql.SelectStatement.getSQLText(SelectStatement.java:654)
        at org.datanucleus.store.rdbms.scostore.MapEntrySetStore.iterator(MapEntrySetStore.java:388)
        at org.datanucleus.store.types.SCOUtils.populateMapDelegateWithStoreData(SCOUtils.java:859)
        at org.datanucleus.store.types.wrappers.backed.Map.loadFromStore(Map.java:296)
        at org.datanucleus.store.types.wrappers.backed.Map.initialise(Map.java:243)
        at org.datanucleus.store.types.TypeManagerImpl.createSCOInstance(TypeManagerImpl.java:473)
        at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.replaceFieldWithWrapper(AbstractContainerMapping.java:442)
        at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.postFetch(AbstractContainerMapping.java:459)
        at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:460)
        at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:316)
        at org.datanucleus.state.StateManagerImpl.loadFieldsFromDatastore(StateManagerImpl.java:1500)
        at org.datanucleus.state.StateManagerImpl.loadUnloadedFieldsInFetchPlan(StateManagerImpl.java:3879)
        at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4094)
        at csm.app.domain.MD_MONA.CE_TechnicalPolicy.dnGetmapOrdinaryActionsLimits(CE_TechnicalPolicy.java)
        at csm.app.domain.MD_MONA.CE_TechnicalPolicy.getMapOrdinaryActionsLimits(CE_TechnicalPolicy.java:383)
        at sun.reflect.GeneratedMethodAccessor820.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:653)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:690)
        ... 115 common frames omitted
```