### PR TITLE
Oracle 12.x Support for the Identity Columns

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/OracleAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/OracleAdapter.java
@@ -179,6 +179,11 @@ public class OracleAdapter extends BaseDatastoreAdapter
         supportedOptions.remove(FK_UPDATE_ACTION_RESTRICT);
         supportedOptions.remove(FK_UPDATE_ACTION_NULL);
         supportedOptions.remove(FK_UPDATE_ACTION_CASCADE);
+		
+        if (datastoreMajorVersion >= 12) 
+        {
+            supportedOptions.add(IDENTITY_COLUMNS);
+        }		
     }
 
     /**


### PR DESCRIPTION
The issue:

We use datanucleous as a supporting tool for test automation. We have an Oracle database. Current Oracle version is 12. 

We have a table: 

```sql
CREATE TABLE "MV_PAYMENT_SCHEME_FORMULA" 
   (	"FORMULA_ID" NUMBER GENERATED ALWAYS AS IDENTITY MINVALUE 1 MAXVALUE 9999999999999999999999999999 INCREMENT BY 1 START WITH 1 CACHE 20 NOORDER  NOCYCLE , 
	"PAYMENT_SCHEME_ID" NUMBER, 
	"CALCULATION_PERIOD_ID" NUMBER, 
	"FORMULA" VARCHAR2(2000 BYTE)
   ) SEGMENT CREATION IMMEDIATE 
``` 

When we map this table as: 

```java
@PersistenceCapable(table = "MV_PAYMENT_SCHEME_FORMULA")
public class MVPaymentSchemeFormula {

    @PrimaryKey
    @Column(name = "FORMULA_ID")
    private Integer formulaId;

    @Column(name = "PAYMENT_SCHEME_ID")
    private MVPaymentScheme paymentScheme;

    @Column(name = "CALCULATION_PERIOD_ID")
    private CalculationPeriod calculationPeriod;

    @Column(name = "FORMULA")
    private String formula;
}
```

then we have on the tryng to make persistable a new object


```
Error : 32795, Position : 87, Sql = INSERT INTO MV_PAYMENT_SCHEME_FORMULA (CALCULATION_PERIOD_ID,FORMULA,PAYMENT_SCHEME_ID,FORMULA_ID) VALUES (:1 ,:2 ,:3 ,:4 ), OriginalSql = INSERT INTO MV_PAYMENT_SCHEME_FORMULA (CALCULATION_PERIOD_ID,FORMULA,PAYMENT_SCHEME_ID,FORMULA_ID) VALUES (?,?,?,?), Error Msg = ORA-32795
```

I think the correct mapping is 

```java
@PersistenceCapable(table = "MV_PAYMENT_SCHEME_FORMULA")
public class MVPaymentSchemeFormula {

    @PrimaryKey
    @Persistent(valueStrategy = IdGeneratorStrategy.IDENTITY)
    @Column(name = "FORMULA_ID")
    private Integer formulaId;

    @Column(name = "PAYMENT_SCHEME_ID")
    private MVPaymentScheme paymentScheme;

    @Column(name = "CALCULATION_PERIOD_ID")
    private CalculationPeriod calculationPeriod;

    @Column(name = "FORMULA")
    private String formula;
}
```
but we have then

```
The exception has been thrown!!!!
javax.jdo.JDOFatalInternalException: Class "xxx.MVPaymentSchemeFormula" has field "formulaId" specified as using autoassign/identity, yet the RDBMS in use doesnt support this feature
```

According to the article identity columns are supported by Oracle since v12. [Article](https://oracle-base.com/articles/12c/identity-columns-in-oracle-12cr1)

With proposed change the inserting is working as expected.