### PR TITLE
Fixes issue 324 - problem with sqlserver and byte arrays

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
@@ -162,6 +162,10 @@ public class SQLServerAdapter extends BaseDatastoreAdapter
         addSQLTypeForJDBCType(handler, mconn, (short)Types.BLOB, sqlType, true);
 
         sqlType = new org.datanucleus.store.rdbms.adapter.SQLServerTypeInfo(
+                "varbinary", (short)Types.VARBINARY, 8000, null, null, "(max)", 1, false, (short)1, false, false, false, "varbinary", (short)0, (short)0, 0);
+        addSQLTypeForJDBCType(handler, mconn, (short)Types.VARBINARY, sqlType, true);
+
+        sqlType = new org.datanucleus.store.rdbms.adapter.SQLServerTypeInfo(
             "TEXT", (short)Types.CLOB, 2147483647, null, null, null, 1, true, (short)1, false, false, false, "TEXT", (short)0, (short)0, 0);
         addSQLTypeForJDBCType(handler, mconn, (short)Types.CLOB, sqlType, true);
 


### PR DESCRIPTION
Fixes problem with byte arrays and mssql server.

The byte array is mapped to a `varbinary` for MS sqlserver. Because there is no creation parameter none ist used and the mssql server makes the guess, that the user likes to have a `varbinary(1)` field. 

Byte arrays are most of the time a bit longer than 1 and so it is rather likely that a INSERT statement result in a exception because the the content needs to be truncated to fit in this small field.

The solution is to create the table with a `varbinary(max)` type for the field and so the data can be added. Because of the nature of the `varbinary` field the used space is optimized. No unused space is wasted.

Hint: The type is named in lowercase to replace the already present `SQLServerTypeInfo` completely.