### PR TITLE
Implemented a fix for the Oracle length semantics issue

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/table/ColumnImpl.java
+++ b/src/main/java/org/datanucleus/store/rdbms/table/ColumnImpl.java
@@ -430,6 +430,23 @@ public class ColumnImpl implements Column
                 {
                     precSpec.append("," + columnMetaData.getScale());
                 }
+                /*
+                 * Starting with version 11.2 Oracle defaults to byte
+                 * as the precision unit for string columns for reasons
+                 * of backwards compatibility. Unfortunately this means
+                 * that the column length attribute is no longer a reliable
+                 * measure for unicode characters if 'char' as a unit is
+                 * omitted from the definition.
+                 */
+                if ("oracle".equals(adapter.getVendorID())) {
+                    double oracleVersion = Double.parseDouble(String.format("%d.%d",
+                        adapter.getDriverMajorVersion(),
+                        adapter.getDriverMinorVersion()
+                    ));
+                    if (oracleVersion >= 11.2 && this.datastoreMapping.isStringBased()) {
+                        precSpec.append(" CHAR");
+                    }
+                }
             }
             else if (sqlPrecision > 0 && !typeInfo.isAllowsPrecisionSpec())
             {


### PR DESCRIPTION
Since version 11.2 Oracle switched to Unicode as the default character encoding and in doing so also had to change the default length semantics attribute `NLS_LENGTH_SEMANTICS` from `char` to `byte` for backwards compatibility reasons.

As a consequence the plain definition of e.g. `VARCHAR2(50)` will default to `VARCHAR2(50 BYTE)` instead of `VARCHAR2(50 CHAR)`. This is at odds with having a reliable measure of the amount of unicode characters one can store in a String column.

Attached below is a proposal for a fix that I've tested with a database of roughly 150 tables.