### PR TITLE
Correctly generate insert statement for no columns with Oracle database

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/OracleAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/OracleAdapter.java
@@ -891,6 +891,12 @@ public class OracleAdapter extends BaseDatastoreAdapter
         return super.getSQLMethodClass(className, methodName, clr);
     }
 
+    @Override
+    public String getInsertStatementForNoColumns(Table table)
+    {
+        return "INSERT INTO " + table.toString() + " VALUES (DEFAULT)";
+    }
+
     /**
      * Load all datastore mappings for this RDBMS database.
      * @param mgr the PluginManager


### PR DESCRIPTION
Override the `getInsertStatementForNoColumns` method in the `OracleAdapter` to correctly generate an insert statement with no columns. This situation can arise when inserting into a table whose only non-nullable column is an identity column whose value will be automatically generated in the datastore.