### PR TITLE
Synchronizing use of WeakHashMap in AbstractIdentifierFactory

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/identifier/AbstractIdentifierFactory.java
+++ b/src/main/java/org/datanucleus/store/rdbms/identifier/AbstractIdentifierFactory.java
@@ -17,6 +17,9 @@
  **********************************************************************/
 package org.datanucleus.store.rdbms.identifier;
 
+import static java.util.Collections.synchronizedMap;
+
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -78,14 +81,14 @@ public abstract class AbstractIdentifierFactory implements IdentifierFactory
     /** Separator to use for words in the identifiers. */
     protected String wordSeparator = "_";
 
-    protected Map<String, DatastoreIdentifier> tables = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> columns = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> foreignkeys = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> indexes = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> candidates = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> primarykeys = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> sequences = new WeakHashMap();
-    protected Map<String, DatastoreIdentifier> references = new WeakHashMap();
+    protected Map<String, DatastoreIdentifier> tables = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> columns = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> foreignkeys = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> indexes = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> candidates = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> primarykeys = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> sequences = synchronizedMap(new WeakHashMap());
+    protected Map<String, DatastoreIdentifier> references = synchronizedMap(new WeakHashMap());
 
     /** Default catalog name for any created identifiers. */
     protected String defaultCatalogName = null;


### PR DESCRIPTION
There are documented instances of threads being stuck in infinite-loop
when calling WeakHashMap.get() or WeakHashMap.put(). get() is also a
mutating method as it expunges stale entries prior to fetching the
object with the key and hence access to both methods have to synchronized.

Examples:
 - https://bz.apache.org/bugzilla/show_bug.cgi?id=50078
 - https://issues.jenkins.io/browse/JENKINS-6528

**Gist with jstack excerpt showing threads stuck in WeakHashMap methods**
The application in concern here is a storm topology with many workers handling application logic that interacts with MySQL, Redis, etc.
https://gist.github.com/rguhan-vzm/b78679623b2155b6b88feab6f7e7f031

I'm also willing to share the flight recording in private that shows the same behavior in a jetty application where the effects are more severe, showing 100% CPU utilization and a lot more threads locked up in WeakHashMap.

This nature of this issue makes it hard to reproduce a deterministic fashion. We deploy a few applications that use DN + JDO over MySQL to our on-prem kubernetes cluster on a daily basis and have seen the issue crop up in 1/2 pods every week. We've handled it by killing faulty pods so far.

The java version we use is 

```
java version "1.8.0_241"
Java(TM) SE Runtime Environment (build 1.8.0_241-b26)
Java HotSpot(TM) 64-Bit Server VM (build 25.241-b26, mixed mode)
```