### PR TITLE
Datanucleus rdbms 5.2.7 application identity

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
@@ -240,7 +240,6 @@ public class InsertRequest extends Request
         {
             VersionMetaData vermd = table.getVersionMetaData();
             RDBMSStoreManager storeMgr = table.getStoreManager();
-            String datastoreProductName =storeMgr.getDatastoreAdapter().getDatastoreProductName();
             if (vermd != null && vermd.getFieldName() != null)
             {
                 // Version field - Update the version in the object
@@ -277,11 +276,10 @@ public class InsertRequest extends Request
                     pkColumnNames = Stream.of(columnMappings)
                         .map(cm -> cm.getColumn().getIdentifier().getName())
                         .collect(toList());
-                    //If the product is Oracle, also if we have a sort of primary key, we should set the pkColumnNames to achieve auto-generated key in Oracle DB
-                } else if (table.getIdentityType() == IdentityType.APPLICATION && ! pkColumns.isEmpty() && datastoreProductName.equals("Oracle")) {
-                    for (Column column : pkColumns) {
-                        pkColumnNames.add(column.getName());
-                    }
+                }
+                else if (table.getIdentityType() == IdentityType.APPLICATION && ! pkColumns.isEmpty())
+                {
+                    pkColumnNames = pkColumns.stream().map(cm->cm.getName()).collect(toList());
                 }
 
                 PreparedStatement ps = sqlControl.getStatementForUpdate(mconn, insertStmt, batch,

--- a/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
@@ -275,6 +275,7 @@ public class InsertRequest extends Request
                         .map(cm -> cm.getColumn().getIdentifier().getName())
                         .collect(toList());
                 }
+                //todo:should handle oracle generated key(auto generated)
 
                 PreparedStatement ps = sqlControl.getStatementForUpdate(mconn, insertStmt, batch,
                     hasIdentityColumn && storeMgr.getDatastoreAdapter().supportsOption(DatastoreAdapter.GET_GENERATED_KEYS_STATEMENT),


### PR DESCRIPTION
Based on Oracle Doc, "The getGeneratedKeys() method enables you to retrieve the auto-generated key fields. The auto-generated keys are returned as a ResultSet object.

If key columns are not explicitly indicated, then Oracle JDBC drivers cannot identify which columns need to be retrieved. When a column name or column index array is used, Oracle JDBC drivers can identify which columns contain auto-generated keys that you want to retrieve. However, when the Statement.RETURN_GENERATED_KEYS integer flag is used; Oracle JDBC drivers cannot identify these columns. When the integer flag is used to indicate that auto-generated keys are to be returned, the ROWID pseudo column is returned as a key. The ROWID can be then fetched from the ResultSet object and can be used to retrieved other columns."

Adding a bit changes to support this issue when using application-identity in Oracle JDBC
