### PR TITLE
Support getGeneratedKeys for IDENTITY with APPLICATION ID

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/InsertRequest.java
@@ -275,6 +275,7 @@ public class InsertRequest extends Request
                         .map(cm -> cm.getColumn().getIdentifier().getName())
                         .collect(toList());
                 }
+                //todo:should handle oracle generated key(auto generated)
 
                 PreparedStatement ps = sqlControl.getStatementForUpdate(mconn, insertStmt, batch,
                     hasIdentityColumn && storeMgr.getDatastoreAdapter().supportsOption(DatastoreAdapter.GET_GENERATED_KEYS_STATEMENT),


### PR DESCRIPTION
Based on Oracle Doc, "The getGeneratedKeys() method enables you to retrieve the auto-generated key fields. The auto-generated keys are returned as a ResultSet object.

If key columns are not explicitly indicated, then Oracle JDBC drivers cannot identify which columns need to be retrieved. When a column name or column index array is used, Oracle JDBC drivers can identify which columns contain auto-generated keys that you want to retrieve. However, when the Statement.RETURN_GENERATED_KEYS integer flag is used; Oracle JDBC drivers cannot identify these columns. When the integer flag is used to indicate that auto-generated keys are to be returned, the ROWID pseudo column is returned as a key. The ROWID can be then fetched from the ResultSet object and can be used to retrieved other columns."

Adding a bit changes to support this issue when using application-identity in Oracle JDBC