### PR TITLE
Slow HashMap update when the new Map is large

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
@@ -298,7 +298,7 @@ public class JoinListStore<E> extends AbstractListStore<E>
                         start++;
 
                         // Execute the statement
-                        sqlControl.executeStatementUpdate(ec, mconn, addStmt, ps, !iter.hasNext());
+                        sqlControl.executeStatementUpdate(ec, mconn, addStmt, ps, !elemIter.hasNext());
                     }
                     finally
                     {

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinMapStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinMapStore.java
@@ -1018,9 +1018,7 @@ public class JoinMapStore<K, V> extends AbstractMapStore<K, V>
      * @param ownerOP ObjectProvider for the owner
      * @param conn The Connection
      * @param batched Whether we are batching it
-     * @param key The key
-     * @param value The new value
-     * @param executeNow Whether to execute the statement now or wait til any batch
+     * @param updates the values to be update by key
      * @throws MappedDatastoreException Thrown if an error occurs
      */
     protected void internalUpdate(ObjectProvider<?> ownerOP, ManagedConnection conn, boolean batched, List<Map.Entry<? extends K, ? extends V>> updates)
@@ -1073,10 +1071,7 @@ public class JoinMapStore<K, V> extends AbstractMapStore<K, V>
      * @param ownerOP ObjectProvider for the owner
      * @param conn The Connection
      * @param batched Whether we are batching it
-     * @param key The key
-     * @param value The value
-     * @param executeNow Whether to execute the statement now or wait til batching
-     * @return The return codes from any executed statement
+     * @param puts the list of key/values being inserted
      * @throws MappedDatastoreException Thrown if an error occurs
      */
     protected void internalPut(ObjectProvider<?> ownerOP, ManagedConnection conn, boolean batched, List<Map.Entry<? extends K, ? extends V>> puts)


### PR DESCRIPTION
Fix 1. Batching in JoinMapStore
-----
Given
```
class Foo{
 HashMap<String, Bar> map;
}
class Bar{
 String value;
}

HashMap<String, Bar> newMap=new HashMap<>();
for(int i=0;i<10000;i++){
  newMap.put(Integer.toString(i), bar);
}

Foo foo = pm.getObjectById(Foo.class, \"1\");
Foo newFoo = new Foo();
pm.makePersistent(newFoo);
```

Slow performance for
`foo.map.clear();`
`foo.map.putAll(newMap);`
or
`foo.map=newMap;`
or
`newFoo.map.clear();`
`newFoo.map.putAll(newMap);`
or
`newFoo.map=newMap;`


Under the hood JoinMapStore.putAll execute getValue for N entity and each introduce a SQL round-trip.
And the internalPut and internalUpdate methods does not using JDBC batch.

As a result 2N of SQL round trip, or O(N) performance.

This naive patch attempt to optimize the logic in to a O(1) by using ONE SELECT statement (reusing MapEntrySetStore).
And enable using the batch API for INSERT/UPDATE operations.

Also overload the method MapEntrySetStore.iterator and attempt to SELECT only given keys, rather than SELECT the whole map.
This should speed up some another case when the map is large and added few entries to it. Avoiding reading unnecessary rows into L1Cache.

With a limitation of only supporting SingleFieldMapping.
With a limitation up to 1024 keys (or fallback to whole table selection).

Tested with MySQL 8.

It is very likely does work with Oracle due to 1000 element IN limit (if I remember it correctly).

It is possible to expand to MultiMapping with DBMS whom support IN with multi columns
(e.g. PostgreSQL (foo,bar) IN ((1,2),(3,4)))
or long where generation for DBMS does not support IN with multi columns
(i.e. foo in (1,3) AND bar IN (2,4) AND ((foo = 1 AND bar=2 ) or (foo=2 AND bar=4)))

But none of these fancy case are current my interest nor priority.

--------
Fix 2.

JoinMapStore incorrectly cached generated `getStmt` (and few other variables) for getValue with FetchPlan. And possibility use it with a another FetchPlan.
Move the cache to queryManager with a cacheKey contains the table name and FetchPlan.

--------
Fix 3.

Simple typo/variable name correction in JoinListStore for better JDBC batch.


