### PR TITLE
Updated the default for the DatastoreId.class definition; it should be a BigInt by default

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
@@ -822,7 +822,7 @@ public class SQLServerAdapter extends BaseDatastoreAdapter
         registerColumnMapping(DatastoreId.class.getName(), org.datanucleus.store.rdbms.mapping.column.NumericColumnMapping.class, JDBCType.NUMERIC, "NUMERIC", false);
         registerColumnMapping(DatastoreId.class.getName(), org.datanucleus.store.rdbms.mapping.column.CharColumnMapping.class, JDBCType.CHAR, "CHAR", false);
         registerColumnMapping(DatastoreId.class.getName(), org.datanucleus.store.rdbms.mapping.column.VarCharColumnMapping.class, JDBCType.VARCHAR, "VARCHAR", false);
-        registerColumnMapping(DatastoreId.class.getName(), org.datanucleus.store.rdbms.mapping.column.IntegerColumnMapping.class, JDBCType.INTEGER, "INT", true);
+        registerColumnMapping(DatastoreId.class.getName(), org.datanucleus.store.rdbms.mapping.column.IntegerColumnMapping.class, JDBCType.INTEGER, "INT", false);
 
         super.loadColumnMappings(mgr, clr);
     }


### PR DESCRIPTION
Typo in the SqlServerAdapter causes the wrong default value to be set.