### PR TITLE
PostgreSQL: Use BIGSERIAL when identity column is mapped to BIGINT

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/DatastoreAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/DatastoreAdapter.java
@@ -569,6 +569,20 @@ public interface DatastoreAdapter
     String getIdentityKeyword(StoreManager storeMgr);
 
     /**
+     * Accessor for the identity (auto-increment) keyword for generating DDLs (CREATE TABLEs...).
+     * Provides the {@link ColumnMapping} as context for data stores that have different identity
+     * keywords based on the mapped Java / JDBC type.
+     * Defaults to {@link #getIdentityKeyword(StoreManager)} for backward-compatibility.
+     * @param storeMgr The Store manager
+     * @param columnMapping The column mapping
+     * @return The keyword for a column using auto-increment/identity
+     */
+    default String getIdentityKeyword(StoreManager storeMgr, ColumnMapping columnMapping)
+    {
+        return getIdentityKeyword(storeMgr);
+    }
+
+    /**
      * Method to return the maximum length of a datastore identifier of the specified type.
      * If no limit exists then returns -1
      * @param identifierType Type of identifier

--- a/src/main/java/org/datanucleus/store/rdbms/adapter/PostgreSQLAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/PostgreSQLAdapter.java
@@ -43,6 +43,8 @@ import org.datanucleus.store.connection.ManagedConnection;
 import org.datanucleus.store.rdbms.identifier.IdentifierFactory;
 import org.datanucleus.store.rdbms.key.Index;
 import org.datanucleus.store.rdbms.key.PrimaryKey;
+import org.datanucleus.store.rdbms.mapping.column.BigIntColumnMapping;
+import org.datanucleus.store.rdbms.mapping.column.ColumnMapping;
 import org.datanucleus.store.rdbms.schema.ForeignKeyInfo;
 import org.datanucleus.store.rdbms.schema.RDBMSColumnInfo;
 import org.datanucleus.store.rdbms.schema.SQLTypeInfo;
@@ -490,12 +492,23 @@ public class PostgreSQLAdapter extends BaseDatastoreAdapter
     }
 
     /**
-     * Accessor for the auto-increment keyword for generating DDLs (CREATE TABLEs...).
-     * @param storeMgr The Store Manager
-     * @return The keyword for a column using auto-increment
+     * Accessor for the identity (auto-increment) keyword for generating DDLs (CREATE TABLEs...).
+     * Provides the {@link ColumnMapping} as context for data stores that have different identity
+     * keywords based on the mapped Java / JDBC type.
+     * @param storeMgr The Store manager
+     * @param columnMapping The column mapping
+     * @return The keyword for a column using auto-increment/identity
      */
-    public String getIdentityKeyword(StoreManager storeMgr)
+    @Override
+    public String getIdentityKeyword(StoreManager storeMgr, ColumnMapping columnMapping)
     {
+        // PostgreSQL differentiates between SERIAL (integer) and BIGSERIAL (bigint).
+        // https://www.postgresql.org/docs/14/datatype-numeric.html
+        if (columnMapping instanceof BigIntColumnMapping)
+        {
+            return "BIGSERIAL";
+        }
+
         return "SERIAL";
     }
 

--- a/src/main/java/org/datanucleus/store/rdbms/table/ColumnImpl.java
+++ b/src/main/java/org/datanucleus/store/rdbms/table/ColumnImpl.java
@@ -524,7 +524,7 @@ public class ColumnImpl implements Column
         // Auto Increment
         if (adapter.supportsOption(DatastoreAdapter.IDENTITY_COLUMNS) && isIdentity())
         {
-            def.append(" " + adapter.getIdentityKeyword(table.getStoreManager()));
+            def.append(" " + adapter.getIdentityKeyword(table.getStoreManager(), columnMapping));
         }
 
         // Uniqueness


### PR DESCRIPTION
The identity keyword for PostgreSQL was hardcoded to `SERIAL`, which lead to gnarly inconsistencies like this:

```java
class User {
    @PrimaryKey
    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
    private long id;

    // ...
}
```

```sql
CREATE TABLE "USER"
(
    "ID" SERIAL -- Wrong: SERIAL is equivalent to integer / int4. Java type is long, so this should be BIGSERIAL
    -- ...
);

CREATE TABLE "USERS_PERMISSIONS"
(
    "USER_ID" int8 NOT NULL -- Correct: int8 aliases bigint
    -- ...
);
```

To solve this I needed additional context about the mapped column type in `DatastoreAdapter#getIdentityKeyword`. Added a new default method to the `DatastoreAdapter` interface, that just calls the original `getIdentityKeyword(StoreManager)` method if not overridden, ensuring that this change is backward compatible.

Fixes #455

Signed-off-by: nscuro <nscuro@protonmail.com>