### PR TITLE
#459 Ensures that join extensions are created in lowercase

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/query/QueryToSQLMapper.java
+++ b/src/main/java/org/datanucleus/store/rdbms/query/QueryToSQLMapper.java
@@ -5154,7 +5154,7 @@ public class QueryToSQLMapper extends AbstractExpressionEvaluator implements Que
             return null;
         }
 
-        String extensionName = "datanucleus.query.jdoql." + alias + ".join";
+        String extensionName = "datanucleus.query.jdoql." + alias.toLowerCase() + ".join";
         JoinType joinType = null;
         if (hasExtension(extensionName))
         {


### PR DESCRIPTION
Ensures that the extensionName for join extensions is always lowercase.
The extensionName in this case is created by using an alias coming from a query expression variable, that could have any casing.
We are making the alias lowercase to guarantee that the extension has always the correct naming.

Signed-off-by: Leyart <leyart@gmail.com>