### PR TITLE
Reverted JoinListStore#internalAdd to non bulk shift insertion strategy to avoid issue #464

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/scostore/AbstractListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/AbstractListStore.java
@@ -603,7 +603,7 @@ public abstract class AbstractListStore<E> extends AbstractCollectionStore<E> im
                 }
 
                 // Execute the statement
-                return sqlControl.executeStatementUpdate(ec, conn, shiftStmt, ps, executeNow);
+                return sqlControl.executeStatementUpdate(ec, conn, shiftBulkStmt, ps, executeNow);
             }
             finally
             {
@@ -612,7 +612,7 @@ public abstract class AbstractListStore<E> extends AbstractCollectionStore<E> im
         }
         catch (SQLException sqle)
         {
-            throw new MappedDatastoreException(shiftStmt, sqle);
+            throw new MappedDatastoreException(shiftBulkStmt, sqle);
         }        
     }
 

--- a/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
+++ b/src/main/java/org/datanucleus/store/rdbms/scostore/JoinListStore.java
@@ -260,13 +260,15 @@ public class JoinListStore<E> extends AbstractListStore<E>
                 // Shift any existing elements so that we can insert the new element(s) at their position
                 if (!atEnd && start != currentListSize)
                 {
-                    internalShiftBulk(op, mconn, true, start-1, shift, true);
-//                    boolean batched = currentListSize - start > 0;
-//                    for (int i = currentListSize - 1; i >= start; i--)
-//                    {
-//                        // Shift the index for this row by "shift"
-//                        internalShift(op, mconn, batched, i, shift, (i == start));
-//                    }
+//                    internalShiftBulk(op, mconn, true, start-1, shift, true);
+// Revert to "one at a time" shifting to see if that fixed the bug with bulk shifting raised by me:
+// https://github.com/datanucleus/datanucleus-rdbms/issues/464
+                    boolean batched = currentListSize - start > 0;
+                    for (int i = currentListSize - 1; i >= start; i--)
+                    {
+                        // Shift the index for this row by "shift"
+                        internalShift(op, mconn, batched, i, shift, (i == start));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Also: Fixed potential typo in passing shiftStmt instead of shiftBulkStmt in AbstractlistStore - did not resolve issue #464

This only reverts the bulk shift for 1-m relationships implemented via join tables as they are the only ones exhibiting the exception in MySQL.

Bulk shifts for 1-m relationships implemented by FK are still in place.
