### PR TITLE
Added HikariCP SQLInit options

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/RDBMSPropertyNames.java
+++ b/src/main/java/org/datanucleus/store/rdbms/RDBMSPropertyNames.java
@@ -83,6 +83,7 @@ public class RDBMSPropertyNames
     public static final String PROPERTY_CONNECTION_POOL_READ_ONLY = "datanucleus.connectionPool.readOnly";
     public static final String PROPERTY_CONNECTION_POOL_TRANSACTION_ISOLATION = "datanucleus.connectionPool.transactionIsolation";
     public static final String PROPERTY_CONNECTION_POOL_CATALOG = "datanucleus.connectionPool.catalog";
+    public static final String PROPERTY_CONNECTION_POOL_INIT_SQL = "datanucleus.connectionPool.connectionInitSQL";
 
     // Oracle specific
     public static final String PROPERTY_RDBMS_ORACLE_NLS_SORT_ORDER = "datanucleus.rdbms.oracle.nlsSortOrder";

--- a/src/main/java/org/datanucleus/store/rdbms/connectionpool/HikariCPConnectionPoolFactory.java
+++ b/src/main/java/org/datanucleus/store/rdbms/connectionpool/HikariCPConnectionPoolFactory.java
@@ -166,6 +166,13 @@ public class HikariCPConnectionPoolFactory extends AbstractConnectionPoolFactory
                 config.setValidationTimeout(validationTimeout);
             }
         }
+    
+        if (storeMgr.hasProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_INIT_SQL))
+        {
+            String connectionInitSQL = storeMgr.getStringProperty(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_INIT_SQL);
+            config.setConnectionInitSql(connectionInitSQL);
+        }
+    
 
         // Create the actual pool of connections
         HikariDataSource ds = new HikariDataSource(config);


### PR DESCRIPTION
Related to #466 , I implemented the option for 5.2

Again this add the connectionInitSQL options as `datanucleus.connectionPool.connectionInitSQL` 


Can you please check and release 5.2.12 if the PR is ok for you, thanks very much that will unblock me