### PR TITLE
Duplicated ID happen on MS SQL Server If run multiple JVM instance.

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/adapter/DatastoreAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/DatastoreAdapter.java
@@ -306,6 +306,9 @@ public interface DatastoreAdapter
     /** Whether the row lock should use SELECT ... FOR UPDATE. */
     public static final String LOCK_ROW_USING_SELECT_FOR_UPDATE = "LockRowUsingSelectForUpdate";
 
+    /** Whether this datastore supports SELECT ... WITH UPDLOCK. */
+    public static final String LOCK_WITH_SELECT_WITH_UPDLOCK = "LockWithSelectWithUpdlock";
+
     /** Whether the row lock, when using SELECT ... FOR UPDATE, should also append NOWAIT. */
     public static final String LOCK_ROW_USING_SELECT_FOR_UPDATE_NOWAIT = "LockRowSelectForUpdateNowait";
 

--- a/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
+++ b/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java
@@ -122,6 +122,7 @@ public class SQLServerAdapter extends BaseDatastoreAdapter
 
         supportedOptions.add(STORED_PROCEDURES);
         supportedOptions.add(ORDERBY_NULLS_USING_CASE_NULL);
+        supportedOptions.add(LOCK_WITH_SELECT_WITH_UPDLOCK);
 
         supportedOptions.remove(BOOLEAN_COMPARISON);
         supportedOptions.remove(DEFERRED_CONSTRAINTS);

--- a/src/main/java/org/datanucleus/store/rdbms/valuegenerator/SequenceTable.java
+++ b/src/main/java/org/datanucleus/store/rdbms/valuegenerator/SequenceTable.java
@@ -117,6 +117,17 @@ public class SequenceTable extends TableImpl
             fetchStmt += " " + dba.getSelectForUpdateText();
         }
 
+        if (dba.supportsOption(DatastoreAdapter.LOCK_WITH_SELECT_WITH_UPDLOCK))
+        {
+            String modifier = " with (updlock)";
+            int wherePos = fetchStmt.toUpperCase().indexOf(" WHERE ");
+            if (wherePos < 0) {
+                fetchStmt = fetchStmt + modifier;
+            }else{
+                fetchStmt = fetchStmt.substring(0, wherePos) + modifier + fetchStmt.substring(wherePos, fetchStmt.length());
+            }
+        }
+
         storeMgr.registerTableInitialized(this);
         state = TABLE_STATE_INITIALIZED;
     }


### PR DESCRIPTION
The original PR - https://github.com/datanucleus/datanucleus-rdbms/pull/354/files

use with (updlock) to support MS SQL Server.