### PR TITLE
Added RDBMS extension for member to specify that updates to member should not trigger version update when using optimistic locking.

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/request/RequestIdentifier.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/RequestIdentifier.java
@@ -37,6 +37,7 @@ public class RequestIdentifier
     private final int hashCode;
     private final String className;
     private final BitSet nullPkFields;
+    private final boolean noVersionUpdate;
 
     /**
      * Constructor.
@@ -62,10 +63,27 @@ public class RequestIdentifier
      */
     public RequestIdentifier(DatastoreClass table, AbstractMemberMetaData[] mmds, AbstractMemberMetaData[] secondaryMmds, RequestType type, String className, BitSet nullPkFields)
     {
+        this(table, mmds, secondaryMmds, type, className, nullPkFields, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param table         Datastore class for which this is a request
+     * @param mmds          MetaData of members to use in the request (if required)
+     * @param secondaryMmds MetaData of secondary members to use the in the request
+     * @param type          The type being represented
+     * @param className     The name of the class
+     * @param nullPkFields  PK fields that are null
+     * @param noVersionUpdate Should we ignore updating version when using optimistic lock?
+     */
+    public RequestIdentifier(DatastoreClass table, AbstractMemberMetaData[] mmds, AbstractMemberMetaData[] secondaryMmds, RequestType type, String className, BitSet nullPkFields, boolean noVersionUpdate)
+    {
         this.table = table;
         this.type = type;
         this.className = className;
         this.nullPkFields = nullPkFields;
+        this.noVersionUpdate = noVersionUpdate;
 
         if (mmds == null)
         {
@@ -99,7 +117,7 @@ public class RequestIdentifier
         }
 
         // Since we are an immutable object, pre-compute the hash code for improved performance in equals()
-        int tmpHash = Objects.hash(table, type, className, nullPkFields);
+        int tmpHash = Objects.hash(table, type, className, nullPkFields, noVersionUpdate);
         tmpHash = 31 * tmpHash + Arrays.hashCode(memberNumbers);
         tmpHash = 31 * tmpHash + Arrays.hashCode(secondaryMemberNumbers);
         hashCode = tmpHash;
@@ -147,7 +165,8 @@ public class RequestIdentifier
 
         return table.equals(ri.table) && type.equals(ri.type) && className.equals(ri.className) &&
                 Objects.equals(nullPkFields, ri.nullPkFields) &&
-                Arrays.equals(memberNumbers, ri.memberNumbers) && 
+                noVersionUpdate == ri.noVersionUpdate &&
+                Arrays.equals(memberNumbers, ri.memberNumbers) &&
                 Arrays.equals(secondaryMemberNumbers, ri.secondaryMemberNumbers);
     }
 }

--- a/src/main/java/org/datanucleus/store/rdbms/request/UpdateRequest.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/UpdateRequest.java
@@ -128,24 +128,26 @@ public class UpdateRequest extends Request
      */
     public UpdateRequest(DatastoreClass table, AbstractMemberMetaData[] reqFieldMetaData, AbstractClassMetaData cmd, ClassLoaderResolver clr)
     {
-        this(table, reqFieldMetaData, cmd, clr, new BitSet(0));
+        this(table, reqFieldMetaData, cmd, clr, new BitSet(0), false);
     }
 
     /**
      * Constructor, taking the table. Uses the structure of the datastore table to build a basic query.
-     * @param table The Class Table representing the datastore table to update
+     *
+     * @param table            The Class Table representing the datastore table to update
      * @param reqFieldMetaData MetaData of the fields to update
-     * @param cmd ClassMetaData of objects being updated
-     * @param clr ClassLoader resolver
-     * @param nullPkFields Fields in PK that are null - only used if PC model has objects with nullable PK fields
+     * @param cmd              ClassMetaData of objects being updated
+     * @param clr              ClassLoader resolver
+     * @param nullPkFields     Fields in PK that are null - only used if PC model has objects with nullable PK fields
+     * @param noVersionUpdate Should we ignore updating version when using optimistic lock?
      */
-    public UpdateRequest(DatastoreClass table, AbstractMemberMetaData[] reqFieldMetaData, AbstractClassMetaData cmd, ClassLoaderResolver clr, BitSet nullPkFields)
+    public UpdateRequest(DatastoreClass table, AbstractMemberMetaData[] reqFieldMetaData, AbstractClassMetaData cmd, ClassLoaderResolver clr, BitSet nullPkFields, boolean noVersionUpdate)
     {
         super(table);
         this.nullPkFields = nullPkFields;
 
         this.cmd = cmd;
-        versionMetaData = table.getVersionMetaData();
+        versionMetaData = noVersionUpdate ? null : table.getVersionMetaData();
         if (versionMetaData != null && versionMetaData.getStrategy() != VersionStrategy.NONE)
         {
             // Only apply a version check if we have a strategy defined

--- a/src/main/java/org/datanucleus/store/rdbms/request/UpdateRequest.java
+++ b/src/main/java/org/datanucleus/store/rdbms/request/UpdateRequest.java
@@ -505,7 +505,7 @@ public class UpdateRequest extends Request
                             if (rows == 0)
                             {
                                 throw new NucleusOptimisticException(
-                                        Localiser.msg("052203", sm.getObjectAsPrintable(), sm.getInternalObjectId(), "" + finalCurrentVersion), sm.getObject());
+                                        Localiser.msg("052203", IdentityUtils.getPersistableIdentityForId(sm.getInternalObjectId()), "" + finalCurrentVersion), sm.getObject());
                             }
                         };
 


### PR DESCRIPTION
Added RDBMS extension for member to specify that updates to member should not trigger version update when using optimistic locking.