### PR TITLE
Fix: Connection factory should ensure listeners' managedConnectionPostClose() method are invoked when closing managed connection

### DIFF
--- a/src/main/java/org/datanucleus/store/rdbms/ConnectionFactoryImpl.java
+++ b/src/main/java/org/datanucleus/store/rdbms/ConnectionFactoryImpl.java
@@ -590,24 +590,24 @@ public class ConnectionFactoryImpl extends AbstractConnectionFactory
                     catch (SQLException sqle)
                     {
                         throw new NucleusDataStoreException(sqle.getMessage(), sqle);
+                    } finally {
+                        for (int i=0;i<listeners.size();i++)
+                        {
+                            listeners.get(i).managedConnectionPostClose();
+                        }
+
+                        if (savepoints != null)
+                        {
+                            savepoints.clear();
+                            savepoints = null;
+                        }
+                        this.xaRes = null;
+                        this.ec = null;
+
+                        super.close();
                     }
                 }
             }
-
-            for (int i=0;i<listeners.size();i++)
-            {
-                listeners.get(i).managedConnectionPostClose();
-            }
-
-            if (savepoints != null)
-            {
-                savepoints.clear();
-                savepoints = null;
-            }
-            this.xaRes = null;
-            this.ec = null;
-
-            super.close();
         }
 
         /**


### PR DESCRIPTION
When the ConnectionFactory fails to close the underlying JDBC connection, the thrown exception prevents the listeners' `managedConnectionPostClose` method from being called. `ManagedConnection` relies on the `managedConnectionPostClose` method to remove itself from the ConnectionManager's ConnectionsCache.

Failure to close the underlying JDBC connection may indicate that the underlying connection is corrupted (e.g., disconnected, lost, etc.). Failure to remove `ManagedConnection` from the ConnectionManager's ConnectionsCache will result in `ManagedConnection` holding corrupted JDBC connections remaining in the cache, leading to their reuse and subsequent errors.